### PR TITLE
Add alternative way of calling contains()

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ class OpenLocationCode implememts Stringable
     public function recover(float $referenceLatitude, float $referenceLongitude): self;
 
     public function contains(float $latitude, float $longitude): bool;
+    // note: if you need to call contains() many times on the same $this, consider decoding $this first, and then call contains() on the resulting CodeArea instance
 
     public static function isValidCode(string $code): bool;
     public function isValid(): bool;
@@ -121,6 +122,8 @@ class CodeArea
 
     public function getCenterLatitude(): float;
     public function getCenterLongitude(): float;
+
+    public function contains(float $latitude, float $longitude): float;
 }
 ```
 

--- a/src/CodeArea.php
+++ b/src/CodeArea.php
@@ -38,4 +38,19 @@ readonly class CodeArea
     {
         return ($this->eastLongitude + $this->westLongitude) / 2;
     }
+
+    /**
+     * Returns whether the bounding box specified by the code area (from a decoded Open Location Code) contains the provided point.
+     * 
+     * @param float $latitude The provided latitude in degrees.
+     * @param float $longitude The provided longitude in degrees.
+     * @return bool True if tge coordinates are contained by the code area.
+     */
+    public function contains(float $latitude, float $longitude): bool
+    {
+        return $this->southLatitude <= $latitude
+            && $latitude < $this->northLatitude
+            && $this->westLongitude <= $longitude
+            && $longitude < $this->eastLongitude;
+    }
 }

--- a/src/CodeArea.php
+++ b/src/CodeArea.php
@@ -44,7 +44,7 @@ readonly class CodeArea
      * 
      * @param float $latitude The provided latitude in degrees.
      * @param float $longitude The provided longitude in degrees.
-     * @return bool True if tge coordinates are contained by the code area.
+     * @return bool True if the coordinates are contained by the code area.
      */
     public function contains(float $latitude, float $longitude): bool
     {

--- a/src/OpenLocationCode.php
+++ b/src/OpenLocationCode.php
@@ -349,6 +349,8 @@ final class OpenLocationCode implements Stringable
     /**
      * Returns whether the bounding box specified by the Open Location Code contains the provided point.
      * 
+     * @see CodeArea::contains() for the underlying implementation.
+     * 
      * @param float $latitude The provided latitude in degrees.
      * @param float $longitude The provided longitude in degrees.
      * @return bool True if tge coordinates are contained by the code.
@@ -356,10 +358,7 @@ final class OpenLocationCode implements Stringable
     public function contains(float $latitude, float $longitude): bool
     {
         $codeArea = $this->decode();
-        return $codeArea->southLatitude <= $latitude
-            && $latitude < $codeArea->northLatitude
-            && $codeArea->westLongitude <= $longitude
-            && $longitude < $codeArea->eastLongitude;
+        return $codeArea->contains($latitude, $longitude);
     }
 
     // ---

--- a/src/OpenLocationCode.php
+++ b/src/OpenLocationCode.php
@@ -353,7 +353,7 @@ final class OpenLocationCode implements Stringable
      * 
      * @param float $latitude The provided latitude in degrees.
      * @param float $longitude The provided longitude in degrees.
-     * @return bool True if tge coordinates are contained by the code.
+     * @return bool True if the coordinates are contained by the code.
      */
     public function contains(float $latitude, float $longitude): bool
     {


### PR DESCRIPTION
See #2 for motivation and the problem.

------

Now, instead of:

```php
$instance = OpenLocationCode::createFromCoordinates(0, 0);
// check containment many times
for ($i = 0; $i < 80; $i++) {
    $instance->contains($i, $i);
}
```

You may now alternatively do:

```php
$instance = OpenLocationCode::createFromCoordinates(0, 0);
// check containment many times
$codeArea = $instance->decode();
for ($i = 0; $i < 80; $i++) {
    $codeArea->contains($i, $i);
}
```

This method slightly increases memory usage (you need to hold an instance of `CodeArea`) but speeds up containment checking since the OLC is decoded only once.

This provides flexibility when needing to check whether many points are contained inside the same Open Location Code area.