### PR TITLE
Use "long" int calculators where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ via Composer:
 composer require vectorial1024/open-location-code-php
 ```
 
-**Special Notice**: to ensure 32-bit PHP compatibility, this library uses `float` variables instead of `int` variables to calculate Open Location Codes.
-This may cause inaccuracies in some unforseen edge cases, but generally speaking, there should be no problems.
+**Special Notice**: to ensure 32-bit PHP compatibility, this library will check the PHP runtime and, if it detects a 32-bit PHP runtime, will use `float` variables instead of `int` variables to calculate Open Location Codes.
+This may cause some unintended inaccuracies in 32-bit PHP, but generally speaking, there should be no problems.
 
 ## Example code
 

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -45,11 +45,11 @@ abstract class AbstractCodeCalculator
     abstract protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string;
 
     /**
-     * Decodes the given (string) Open Location Code into a CodeArea object encapsulating latitude/longitude bounding box.
-     * @param string $code The Open Location Code in string format
+     * Assuming the given (string) Open Location Code is valid and stripped, decodes it into a CodeArea object encapsulating latitude/longitude bounding box.
+     * @param string $strippedCode The stripped Open Location Code
      * @return CodeArea A CodeArea object.
      */
-    abstract public function decode(string $code): CodeArea;
+    abstract public function decode(string $strippedCode): CodeArea;
 
     /**
      * Returns a static instance of the appropriate code calculator depending on whether the current PHP is 32-bit/64-bit.

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -53,11 +53,24 @@ abstract class AbstractCodeCalculator
     abstract protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string;
 
     /**
-     * Assuming the given (string) Open Location Code is valid and stripped, decodes it into a CodeArea object encapsulating latitude/longitude bounding box.
+     * Assuming the given Open Location Code is valid, decodes it into a CodeArea object encapsulating latitude/longitude bounding box.
+     * @param string $code The stripped Open Location Code.
+     * @return CodeArea A CodeArea object.
+     */
+    public function decode(string $code): CodeArea
+    {
+        // Strip padding and separator characters out of the code.
+        $clean = str_replace([OpenLocationCode::SEPARATOR, OpenLocationCode::PADDING_CHARACTER], "", $code);
+
+        return $this->generateCodeArea($clean);
+    }
+
+    /**
+     * Performs the necessary calculation to generate a CodeArea object from the given (stripped) Open Location Code.
      * @param string $strippedCode The stripped Open Location Code.
      * @return CodeArea A CodeArea object.
      */
-    abstract public function decode(string $strippedCode): CodeArea;
+    abstract protected function generateCodeArea(string $strippedCode): CodeArea;
 
     /**
      * Returns a static instance of the appropriate code calculator depending on whether the current PHP is 32-bit/64-bit.

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -61,18 +61,18 @@ abstract class AbstractCodeCalculator
 
     /**
      * Returns a static instance of the appropriate code calculator depending on whether the current PHP is 32-bit/64-bit.
-     * 
      * 32-bit PHP will get a calculator that uses floats, while 64-bit PHP will get a calculator that uses "long" ints.
      * 
-     * This is required to allow 32-bit PHP environments to correctly calculate Open Location Codes.
-     * 
-     * @return CodeCalculatorFloat The appropriate code calculator.
+     * This is required to allow 32-bit PHP environments to correctly calculate Open Location Codes, while preserving
+     * the performance advantage of 64-bit PHP by using integer operations.
+     * @return CodeCalculatorFloat|CodeCalculatorInt The appropriate code calculator.
      */
-    public static function getDefaultCalculator(): CodeCalculatorFloat
+    public static function getDefaultCalculator(): CodeCalculatorFloat|CodeCalculatorInt
     {
-        // always give float calculator for now
-        // todo check platform status to give int calculator
-        static $defaultCalculator = new CodeCalculatorFloat();
+        // check PHP environment to give int calculator where possible
+        // 32-bit PHP has 32-bit int, which uses 4 bytes i.e. PHP_INT_SIZE = 4
+        // initializing static variables with constructors is only allowed for PHP 8.3+
+        static $defaultCalculator = PHP_INT_SIZE > 4 ? new CodeCalculatorInt() : new CodeCalculatorFloat();
         return $defaultCalculator;
     }
 }

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -46,7 +46,7 @@ abstract class AbstractCodeCalculator
 
     /**
      * Assuming the given (string) Open Location Code is valid and stripped, decodes it into a CodeArea object encapsulating latitude/longitude bounding box.
-     * @param string $strippedCode The stripped Open Location Code
+     * @param string $strippedCode The stripped Open Location Code.
      * @return CodeArea A CodeArea object.
      */
     abstract public function decode(string $strippedCode): CodeArea;

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -10,6 +10,14 @@ use Vectorial1024\OpenLocationCodePhp\OpenLocationCode;
  */
 abstract class AbstractCodeCalculator
 {
+    // Value to multiple latitude degrees to convert it to an integer with the maximum encoding
+    // precision. I.e. ENCODING_BASE**3 * GRID_ROWS**GRID_CODE_LENGTH
+    protected const int LAT_INTEGER_MULTIPLIER = 8000 * 3125;
+
+    // Value to multiple longitude degrees to convert it to an integer with the maximum encoding
+    // precision. I.e. ENCODING_BASE**3 * GRID_COLUMNS**GRID_CODE_LENGTH
+    protected const int LNG_INTEGER_MULTIPLIER = 8000 * 1024;
+
     /**
      * Assuming the given latitude and longitude are valid, encode these coordinates into an Open Location Code.
      * @param float $latitude The latitude in decimal degrees.

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -57,10 +57,14 @@ abstract class AbstractCodeCalculator
      * 32-bit PHP will get a calculator that uses floats, while 64-bit PHP will get a calculator that uses "long" ints.
      * 
      * This is required to allow 32-bit PHP environments to correctly calculate Open Location Codes.
+     * 
+     * @return CodeCalculatorFloat The appropriate code calculator.
      */
-    public static function getDefaultCalculator()
+    public static function getDefaultCalculator(): CodeCalculatorFloat
     {
-        // todo
-        return null;
+        // always give float calculator for now
+        // todo check platform status to give int calculator
+        static $defaultCalculator = new CodeCalculatorFloat();
+        return $defaultCalculator;
     }
 }

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -21,7 +21,7 @@ abstract class AbstractCodeCalculator
     /**
      * Decodes the given (string) Open Location Code into a CodeArea object encapsulating latitude/longitude bounding box.
      * @param string $code The Open Location Code in string format
-     * @return CodeArea The resulting Code Area.
+     * @return CodeArea A CodeArea object.
      */
     abstract public function decode(string $code): CodeArea;
 

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Vectorial1024\OpenLocationCodePhp\CodeCalculator;
+
+use \Vectorial1024\OpenLocationCodePhp\CodeArea;
+
+/**
+ * An abstract class to provide a unified API for the 32-bit and 64-bit Open Location Code calculators.
+ */
+abstract class AbstractCodeCalculator
+{
+    /**
+     * Assuming the given latitude and longitude are valid, encode these coordinates into an Open Location Code.
+     * @param float $latitude The latitude in decimal degrees.
+     * @param float $longitude The longitude in decimal degrees.
+     * @param int $codeLength The desired number of digits in the code.
+     * @return string The resulting (string) Open Location Code.
+     */
+    abstract public function encode(float $latitude, float $longitude, int $codeLength): string;
+
+    /**
+     * Decodes the given (string) Open Location Code into a CodeArea object encapsulating latitude/longitude bounding box.
+     * @param string $code The Open Location Code in string format
+     * @return CodeArea The resulting Code Area.
+     */
+    abstract public function decode(string $code): CodeArea;
+
+    /**
+     * Returns a static instance of the appropriate code calculator depending on whether the current PHP is 32-bit/64-bit.
+     * 
+     * 32-bit PHP will get a calculator that uses floats, while 64-bit PHP will get a calculator that uses "long" ints.
+     * 
+     * This is required to allow 32-bit PHP environments to correctly calculate Open Location Codes.
+     */
+    public static function getDefaultCalculator()
+    {
+        // todo
+        return null;
+    }
+}

--- a/src/CodeCalculator/AbstractCodeCalculator.php
+++ b/src/CodeCalculator/AbstractCodeCalculator.php
@@ -35,13 +35,6 @@ abstract class AbstractCodeCalculator
     }
 
     /**
-     * Decodes the given (string) Open Location Code into a CodeArea object encapsulating latitude/longitude bounding box.
-     * @param string $code The Open Location Code in string format
-     * @return CodeArea A CodeArea object.
-     */
-    abstract public function decode(string $code): CodeArea;
-
-    /**
      * Performs the necessary calculation to generate a reversed (and possibly incomplete) Open Location Code from the given coordinates.
      * The exact implementation depends on whether the 32-bit/64-bit calculator is used, but the idea should be the same.
      * @param float $latitude The latitude in decimal degrees.
@@ -50,6 +43,13 @@ abstract class AbstractCodeCalculator
      * @return string The resulting (string) Open Location Code.
      */
     abstract protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string;
+
+    /**
+     * Decodes the given (string) Open Location Code into a CodeArea object encapsulating latitude/longitude bounding box.
+     * @param string $code The Open Location Code in string format
+     * @return CodeArea A CodeArea object.
+     */
+    abstract public function decode(string $code): CodeArea;
 
     /**
      * Returns a static instance of the appropriate code calculator depending on whether the current PHP is 32-bit/64-bit.

--- a/src/CodeCalculator/CodeCalculatorFloat.php
+++ b/src/CodeCalculator/CodeCalculatorFloat.php
@@ -71,7 +71,7 @@ class CodeCalculatorFloat extends AbstractCodeCalculator
         return $revCode;
     }
 
-    public function decode(string $strippedCode): CodeArea
+    protected function generateCodeArea(string $strippedCode): CodeArea
     {
         // Initialize the values. 
         // We will assume these values are floats to ensure 32bit PHP compatibility.

--- a/src/CodeCalculator/CodeCalculatorFloat.php
+++ b/src/CodeCalculator/CodeCalculatorFloat.php
@@ -85,7 +85,7 @@ class CodeCalculatorFloat extends AbstractCodeCalculator
             $latPlaceVal = floor($latPlaceVal / OpenLocationCode::ENCODING_BASE);
             $lngPlaceVal = floor($lngPlaceVal / OpenLocationCode::ENCODING_BASE);
             $latVal += strpos(OpenLocationCode::CODE_ALPHABET, $strippedCode[$i]) * $latPlaceVal;
-            $lngVal = strpos(OpenLocationCode::CODE_ALPHABET, $strippedCode[$i + 1]) * $lngPlaceVal;
+            $lngVal += strpos(OpenLocationCode::CODE_ALPHABET, $strippedCode[$i + 1]) * $lngPlaceVal;
         }
         unset($i);
         for ($i = OpenLocationCode::PAIR_CODE_LENGTH; $i < min(strlen($strippedCode), OpenLocationCode::MAX_DIGIT_COUNT); $i++) {

--- a/src/CodeCalculator/CodeCalculatorFloat.php
+++ b/src/CodeCalculator/CodeCalculatorFloat.php
@@ -13,11 +13,11 @@ class CodeCalculatorFloat extends AbstractCodeCalculator
 {
     // Value of the most significant latitude digit after it has been converted to an integer.
     // Note: to ensure 32bit PHP compatibility, this is now a precisely-represented float.
-    public const float LAT_MSP_VALUE = OpenLocationCode::LAT_INTEGER_MULTIPLIER * OpenLocationCode::ENCODING_BASE * OpenLocationCode::ENCODING_BASE;
+    public const float LAT_MSP_VALUE = self::LAT_INTEGER_MULTIPLIER * OpenLocationCode::ENCODING_BASE * OpenLocationCode::ENCODING_BASE;
 
     // Value of the most significant longitude digit after it has been converted to an integer.
     // Note: to ensure 32bit PHP compatibility, this is now a precisely-represented float.
-    public const float LNG_MSP_VALUE = OpenLocationCode::LNG_INTEGER_MULTIPLIER * OpenLocationCode::ENCODING_BASE * OpenLocationCode::ENCODING_BASE;
+    public const float LNG_MSP_VALUE = self::LNG_INTEGER_MULTIPLIER * OpenLocationCode::ENCODING_BASE * OpenLocationCode::ENCODING_BASE;
 
     protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string
     {

--- a/src/CodeCalculator/CodeCalculatorFloat.php
+++ b/src/CodeCalculator/CodeCalculatorFloat.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Vectorial1024\OpenLocationCodePhp\CodeCalculator;
+
+use Vectorial1024\OpenLocationCodePhp\CodeArea;
+use Vectorial1024\OpenLocationCodePhp\OpenLocationCode;
+
+/**
+ * A Open Location Code calculator that uses float.
+ * As such, this is usable on any PHP version.
+ */
+class CodeCalculatorFloat extends AbstractCodeCalculator
+{
+    protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string
+    {
+        // todo
+        return "";
+    }
+
+    public function decode(string $code): CodeArea
+    {
+        // todo
+        return new CodeArea(0, 0, 0, 0, 0);
+    }
+}

--- a/src/CodeCalculator/CodeCalculatorFloat.php
+++ b/src/CodeCalculator/CodeCalculatorFloat.php
@@ -7,14 +7,60 @@ use Vectorial1024\OpenLocationCodePhp\OpenLocationCode;
 
 /**
  * A Open Location Code calculator that uses float.
- * As such, this is usable on any PHP version.
+ * As such, this is usable on any PHP version. but may have unforeseen inaccuracy.
  */
 class CodeCalculatorFloat extends AbstractCodeCalculator
 {
     protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string
     {
-        // todo
-        return "";
+        // PHP has native support for string concatenation, and string reversal is quite fast.
+        $revCode = "";
+
+        // Compute the code.
+        // The idea of this approach is to convert each value to an integer 
+        // after multiplying it by the final precision. 
+        // This allows us to use only integer operations, so
+        // avoiding any accumulation of floating point representation errors.
+        // However, it must also be noted that the calculation may poduce 10-digit integers
+        // that begins with 6, which overflows the 32-bit PHP int type.
+        // The good news is, this relatively small bignum can be precisely represented
+        // by the double-precision float type. We just need to be careful when calculating.
+
+        // Multiply values by their precision and convert to positive.
+        // Rounding avoids/minimizes errors due to floating-point precision.
+        // Since the numbers are positive, floor() is equivalent to intval().
+        $latVal = floor(round(($latitude + OpenLocationCode::LATITUDE_MAX) * OpenLocationCode::LAT_INTEGER_MULTIPLIER * 1e6) / 1e6);
+        $lngVal = floor(round(($longitude + OpenLocationCode::LONGITUDE_MAX) * OpenLocationCode::LNG_INTEGER_MULTIPLIER * 1e6) / 1e6);
+
+        // Compute the grid part of the code if necessary.
+        if ($codeLength > OpenLocationCode::PAIR_CODE_LENGTH) {
+            for ($i = 0; $i < OpenLocationCode::GRID_CODE_LENGTH; $i++) {
+                $latDigit = (int) fmod($latVal, OpenLocationCode::GRID_ROWS);
+                $lngDigit = (int) fmod($lngVal, OpenLocationCode::GRID_COLUMNS);
+                $ndx = $latDigit * OpenLocationCode::GRID_COLUMNS + $lngDigit;
+                $revCode .= OpenLocationCode::CODE_ALPHABET[$ndx];
+                $latVal = floor($latVal / OpenLocationCode::GRID_ROWS);
+                $lngVal = floor($lngVal / OpenLocationCode::GRID_COLUMNS);
+            }
+            unset($i, $latDigit, $lngDigit, $ndx);
+        } else {
+            $latVal = floor($latVal / pow(OpenLocationCode::GRID_ROWS, OpenLocationCode::GRID_CODE_LENGTH));
+            $lngVal = floor($lngVal / pow(OpenLocationCode::GRID_COLUMNS, OpenLocationCode::GRID_CODE_LENGTH));
+        }
+
+        // Compute the pair section of the code.
+        for ($i = 0; $i < intdiv(OpenLocationCode::PAIR_CODE_LENGTH, 2); $i++) {
+            $revCode .= OpenLocationCode::CODE_ALPHABET[(int) fmod($lngVal, OpenLocationCode::ENCODING_BASE)];
+            $revCode .= OpenLocationCode::CODE_ALPHABET[(int) fmod($latVal, OpenLocationCode::ENCODING_BASE)];
+            $latVal = floor($latVal / OpenLocationCode::ENCODING_BASE);
+            $lngVal = floor($lngVal / OpenLocationCode::ENCODING_BASE);
+            // If we are at the separator position, add the separator
+            if ($i == 0) {
+                $revCode .= OpenLocationCode::SEPARATOR;
+            }
+        }
+        
+        return $revCode;
     }
 
     public function decode(string $code): CodeArea

--- a/src/CodeCalculator/CodeCalculatorFloat.php
+++ b/src/CodeCalculator/CodeCalculatorFloat.php
@@ -37,8 +37,8 @@ class CodeCalculatorFloat extends AbstractCodeCalculator
         // Multiply values by their precision and convert to positive.
         // Rounding avoids/minimizes errors due to floating-point precision.
         // Since the numbers are positive, floor() is equivalent to intval().
-        $latVal = floor(round(($latitude + OpenLocationCode::LATITUDE_MAX) * OpenLocationCode::LAT_INTEGER_MULTIPLIER * 1e6) / 1e6);
-        $lngVal = floor(round(($longitude + OpenLocationCode::LONGITUDE_MAX) * OpenLocationCode::LNG_INTEGER_MULTIPLIER * 1e6) / 1e6);
+        $latVal = floor(round(($latitude + OpenLocationCode::LATITUDE_MAX) * self::LAT_INTEGER_MULTIPLIER * 1e6) / 1e6);
+        $lngVal = floor(round(($longitude + OpenLocationCode::LONGITUDE_MAX) * self::LNG_INTEGER_MULTIPLIER * 1e6) / 1e6);
 
         // Compute the grid part of the code if necessary.
         if ($codeLength > OpenLocationCode::PAIR_CODE_LENGTH) {
@@ -76,8 +76,8 @@ class CodeCalculatorFloat extends AbstractCodeCalculator
         // Initialize the values. 
         // We will assume these values are floats to ensure 32bit PHP compatibility.
         // See relevant comments in encode() above.
-        $latVal = -OpenLocationCode::LATITUDE_MAX * OpenLocationCode::LAT_INTEGER_MULTIPLIER;
-        $lngVal = -OpenLocationCode::LONGITUDE_MAX * OpenLocationCode::LNG_INTEGER_MULTIPLIER;
+        $latVal = -OpenLocationCode::LATITUDE_MAX * self::LAT_INTEGER_MULTIPLIER;
+        $lngVal = -OpenLocationCode::LONGITUDE_MAX * self::LNG_INTEGER_MULTIPLIER;
         // Define the place value for the digits. We'll divide this down as we work through the code.
         $latPlaceVal = self::LAT_MSP_VALUE;
         $lngPlaceVal = self::LNG_MSP_VALUE;
@@ -99,10 +99,10 @@ class CodeCalculatorFloat extends AbstractCodeCalculator
             unset($digit);
         }
         unset($i);
-        $latitudeLo = $latVal / OpenLocationCode::LAT_INTEGER_MULTIPLIER;
-        $longitudeLo = $lngVal / OpenLocationCode::LNG_INTEGER_MULTIPLIER;
-        $latitudeHi = ($latVal + $latPlaceVal) / OpenLocationCode::LAT_INTEGER_MULTIPLIER;
-        $longitudeHi = ($lngVal + $lngPlaceVal) / OpenLocationCode::LNG_INTEGER_MULTIPLIER;
+        $latitudeLo = $latVal / self::LAT_INTEGER_MULTIPLIER;
+        $longitudeLo = $lngVal / self::LNG_INTEGER_MULTIPLIER;
+        $latitudeHi = ($latVal + $latPlaceVal) / self::LAT_INTEGER_MULTIPLIER;
+        $longitudeHi = ($lngVal + $lngPlaceVal) / self::LNG_INTEGER_MULTIPLIER;
         return new CodeArea(
             $latitudeLo,
             $longitudeLo,

--- a/src/CodeCalculator/CodeCalculatorInt.php
+++ b/src/CodeCalculator/CodeCalculatorInt.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Vectorial1024\OpenLocationCodePhp\CodeCalculator;
+
+use RuntimeException;
+use Vectorial1024\OpenLocationCodePhp\CodeArea;
+use Vectorial1024\OpenLocationCodePhp\OpenLocationCode;
+
+/**
+ * A Open Location Code calculator that uses "long" int.
+ * As such, this has ensured accuracy, but cannot be used in 32-bit PHP.
+ */
+class CodeCalculatorInt extends AbstractCodeCalculator
+{
+    // Value of the most significant latitude digit after it has been converted to an integer.
+    // Note: since we are using 64-bit PHP, this can be an int.
+    public const int LAT_MSP_VALUE = self::LAT_INTEGER_MULTIPLIER * OpenLocationCode::ENCODING_BASE * OpenLocationCode::ENCODING_BASE;
+
+    // Value of the most significant longitude digit after it has been converted to an integer.
+    // Note: since we are using 64-bit PHP, this can be an int.
+    public const int LNG_MSP_VALUE = self::LNG_INTEGER_MULTIPLIER * OpenLocationCode::ENCODING_BASE * OpenLocationCode::ENCODING_BASE;
+
+    public function __construct()
+    {
+        if (PHP_INT_SIZE < 8) {
+            // 32-bit PHP has 32-bit int, which uses 4 bytes i.e. PHP_INT_SIZE = 4
+            throw new RuntimeException("CodeCalculatorInt cannot be used due to bad PHP_INT_MAX value. Use CodeCalculatorFloat instead.");
+        }
+    }
+
+    protected function generateRevOlcCode(float $latitude, float $longitude, int $codeLength): string
+    {
+        // PHP has native support for string concatenation, and string reversal is quite fast.
+        $revCode = "";
+
+        // Compute the code.
+        // The idea of this approach is to convert each value to an integer 
+        // after multiplying it by the final precision. 
+        // This allows us to use only integer operations, so
+        // avoiding any accumulation of floating point representation errors.
+
+        // Multiply values by their precision and convert to positive.
+        // Rounding avoids/minimises errors due to floating point precision.
+        $latVal = intdiv((int) round(($latitude + OpenLocationCode::LATITUDE_MAX) * self::LAT_INTEGER_MULTIPLIER * 1e6), 1e6);
+        $lngVal = intdiv((int) round(($longitude + OpenLocationCode::LONGITUDE_MAX) * self::LNG_INTEGER_MULTIPLIER * 1e6), 1e6);
+
+        // Compute the grid part of the code if necessary.
+        if ($codeLength > OpenLocationCode::PAIR_CODE_LENGTH) {
+            for ($i = 0; $i < OpenLocationCode::GRID_CODE_LENGTH; $i++) {
+                $latDigit = $latVal % OpenLocationCode::GRID_ROWS;
+                $lngDigit = $lngVal % OpenLocationCode::GRID_COLUMNS;
+                $ndx = $latDigit * OpenLocationCode::GRID_COLUMNS + $lngDigit;
+                $revCode .= OpenLocationCode::CODE_ALPHABET[$ndx];
+                $latVal = intdiv($latVal, OpenLocationCode::GRID_ROWS);
+                $lngVal = intdiv($lngVal, OpenLocationCode::GRID_COLUMNS);
+            }
+            unset($i, $latDigit, $lngDigit, $ndx);
+        } else {
+            $latVal = (int) ($latVal / pow(OpenLocationCode::GRID_ROWS, OpenLocationCode::GRID_CODE_LENGTH));
+            $lngVal = (int) ($lngVal / pow(OpenLocationCode::GRID_COLUMNS, OpenLocationCode::GRID_CODE_LENGTH));
+        }
+
+        // Compute the pair section of the code.
+        for ($i = 0; $i < intdiv(OpenLocationCode::PAIR_CODE_LENGTH, 2); $i++) {
+            $revCode .= OpenLocationCode::CODE_ALPHABET[$lngVal % OpenLocationCode::ENCODING_BASE];
+            $revCode .= OpenLocationCode::CODE_ALPHABET[$latVal % OpenLocationCode::ENCODING_BASE];
+            $latVal = intdiv($latVal, OpenLocationCode::ENCODING_BASE);
+            $lngVal = intdiv($lngVal, OpenLocationCode::ENCODING_BASE);
+            // If we are at the separator position, add the separator
+            if ($i == 0) {
+                $revCode .= OpenLocationCode::SEPARATOR;
+            }
+        }
+
+        return $revCode;
+    }
+
+    public function decode(string $strippedCode): CodeArea
+    {
+        // Initialize the values. 
+        $latVal = -OpenLocationCode::LATITUDE_MAX * self::LAT_INTEGER_MULTIPLIER;
+        $lngVal = -OpenLocationCode::LONGITUDE_MAX * self::LNG_INTEGER_MULTIPLIER;
+        // Define the place value for the digits. We'll divide this down as we work through the code.
+        $latPlaceVal = self::LAT_MSP_VALUE;
+        $lngPlaceVal = self::LNG_MSP_VALUE;
+        for ($i = OpenLocationCode::PAIR_CODE_LENGTH; $i < min(strlen($strippedCode), OpenLocationCode::MAX_DIGIT_COUNT); $i += 2) {
+            $latPlaceVal = intdiv($latPlaceVal, OpenLocationCode::ENCODING_BASE);
+            $lngPlaceVal = intdiv($lngPlaceVal, OpenLocationCode::ENCODING_BASE);
+            $latVal += strpos(OpenLocationCode::CODE_ALPHABET, $strippedCode[$i]) * $latPlaceVal;
+            $lngVal = strpos(OpenLocationCode::CODE_ALPHABET, $strippedCode[$i + 1]) * $lngPlaceVal;
+        }
+        unset($i);
+        for ($i = OpenLocationCode::PAIR_CODE_LENGTH; $i < min(strlen($strippedCode), OpenLocationCode::MAX_DIGIT_COUNT); $i++) {
+            $latPlaceVal = intdiv($latPlaceVal, OpenLocationCode::GRID_ROWS);
+            $lngPlaceVal = intdiv($lngPlaceVal, OpenLocationCode::GRID_COLUMNS);
+            $digit = strpos(OpenLocationCode::CODE_ALPHABET, $strippedCode[$i]);
+            $row = intdiv($digit, OpenLocationCode::GRID_COLUMNS);
+            $col = $digit % OpenLocationCode::GRID_COLUMNS;
+            $latVal += $row * $latPlaceVal;
+            $lngVal += $col * $lngPlaceVal;
+            unset($digit);
+        }
+        unset($i);
+        $latitudeLo = $latVal / self::LAT_INTEGER_MULTIPLIER;
+        $longitudeLo = $lngVal / self::LNG_INTEGER_MULTIPLIER;
+        $latitudeHi = ($latVal + $latPlaceVal) / self::LAT_INTEGER_MULTIPLIER;
+        $longitudeHi = ($lngVal + $lngPlaceVal) / self::LNG_INTEGER_MULTIPLIER;
+        return new CodeArea(
+            $latitudeLo,
+            $longitudeLo,
+            $latitudeHi,
+            $longitudeHi,
+            min(strlen($strippedCode), OpenLocationCode::MAX_DIGIT_COUNT),
+        );
+    }
+}

--- a/src/CodeCalculator/CodeCalculatorInt.php
+++ b/src/CodeCalculator/CodeCalculatorInt.php
@@ -75,7 +75,7 @@ class CodeCalculatorInt extends AbstractCodeCalculator
         return $revCode;
     }
 
-    public function decode(string $strippedCode): CodeArea
+    protected function generateCodeArea(string $strippedCode): CodeArea
     {
         // Initialize the values. 
         $latVal = -OpenLocationCode::LATITUDE_MAX * self::LAT_INTEGER_MULTIPLIER;

--- a/src/OpenLocationCode.php
+++ b/src/OpenLocationCode.php
@@ -143,12 +143,10 @@ final class OpenLocationCode implements Stringable
         if (!$this->isFull()) {
             throw new LogicException("Method decode() may only be called on valid full codes, but code was {$this->code}.");
         }
-        // Strip padding and separator characters out of the code.
-        $clean = str_replace([self::SEPARATOR, self::PADDING_CHARACTER], "", $this->code);
 
         // Delegate to the correct Code Calculator to decode the OLC code for 32-bit/64-bit platforms
         $calculator = AbstractCodeCalculator::getDefaultCalculator();
-        return $calculator->decode($clean);
+        return $calculator->decode($this->code);
     }
 
     public function __toString(): string

--- a/src/OpenLocationCode.php
+++ b/src/OpenLocationCode.php
@@ -54,21 +54,7 @@ final class OpenLocationCode implements Stringable
     // Number of rows in the grid refinement method.
     public const int GRID_ROWS = 5;
 
-    // Value to multiple latitude degrees to convert it to an integer with the maximum encoding
-    // precision. I.e. ENCODING_BASE**3 * GRID_ROWS**GRID_CODE_LENGTH
-    public const int LAT_INTEGER_MULTIPLIER = 8000 * 3125;
-
-    // Value to multiple longitude degrees to convert it to an integer with the maximum encoding
-    // precision. I.e. ENCODING_BASE**3 * GRID_COLUMNS**GRID_CODE_LENGTH
-    public const int LNG_INTEGER_MULTIPLIER = 8000 * 1024;
-
-    // Value of the most significant latitude digit after it has been converted to an integer.
-    // Note: to ensure 32bit PHP compatibility, this is now a precisely-represented float.
-    private const float LAT_MSP_VALUE = self::LAT_INTEGER_MULTIPLIER * self::ENCODING_BASE * self::ENCODING_BASE;
-
-    // Value of the most significant longitude digit after it has been converted to an integer.
-    // Note: to ensure 32bit PHP compatibility, this is now a precisely-represented float.
-    private const float LNG_MSP_VALUE = self::LNG_INTEGER_MULTIPLIER * self::ENCODING_BASE * self::ENCODING_BASE;
+    // Note: constants that are only for encoding/decoding are moved to AbstractCodeCalculator.
 
     // The 360 degree circle information to normalize longitudes.
     private const int CIRCLE_DEG = 2 * self::LONGITUDE_MAX;

--- a/src/OpenLocationCode.php
+++ b/src/OpenLocationCode.php
@@ -204,7 +204,7 @@ final class OpenLocationCode implements Stringable
 
     /**
      * Decodes this object into a CodeArea object encapsulating latitude/longitude bounding box.
-     * @return void
+     * @return CodeArea A CodeArea object.
      */
     public function decode(): CodeArea
     {

--- a/test/OpenLocationCodeTest.php
+++ b/test/OpenLocationCodeTest.php
@@ -9,6 +9,11 @@ use Vectorial1024\OpenLocationCodePhp\OpenLocationCode;
 
 class OpenLocationCodeTest extends TestCase
 {
+    public function testCorrectConstants(): void
+    {
+        $this->assertEquals(OpenLocationCode::ENCODING_BASE, strlen(OpenLocationCode::CODE_ALPHABET));
+    }
+
     #[DataProvider('codeValidityProvider')]
     public function testCorrectCodeValidity(?string $testCode, bool $expectedValidity): void
     {

--- a/test/OpenLocationCodeTest.php
+++ b/test/OpenLocationCodeTest.php
@@ -5,6 +5,8 @@ namespace Vectorial1024\OpenLocationCodePhp\Test;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Vectorial1024\OpenLocationCodePhp\CodeCalculator\CodeCalculatorFloat;
+use Vectorial1024\OpenLocationCodePhp\CodeCalculator\CodeCalculatorInt;
 use Vectorial1024\OpenLocationCodePhp\OpenLocationCode;
 
 class OpenLocationCodeTest extends TestCase
@@ -38,6 +40,17 @@ class OpenLocationCodeTest extends TestCase
         $this->assertEquals($expectedCode, $codeObject->code);
         // while OLC represents an area via lossful encoding, at least the area should contain the original point
         $this->assertTrue($codeObject->contains($latitude, $longitude));
+
+        // for convenience, also test the code calculators here
+        $floatCal = new CodeCalculatorFloat();
+        $resultCode = $floatCal->encode($latitude, $longitude, OpenLocationCode::CODE_PRECISION_NORMAL);
+        $this->assertEquals($resultCode, $expectedCode);
+        if (PHP_INT_SIZE >= 8) {
+            // at least 64-bit, which means we can use "long" ints here
+            $intCal = new CodeCalculatorInt();
+            $resultCode = $intCal->encode($latitude, $longitude, OpenLocationCode::CODE_PRECISION_NORMAL);
+            $this->assertEquals($resultCode, $expectedCode);
+        }
     }
 
     public static function codeValidityProvider(): array

--- a/test/OpenLocationCodeTest.php
+++ b/test/OpenLocationCodeTest.php
@@ -45,11 +45,15 @@ class OpenLocationCodeTest extends TestCase
         $floatCal = new CodeCalculatorFloat();
         $resultCode = $floatCal->encode($latitude, $longitude, OpenLocationCode::CODE_PRECISION_NORMAL);
         $this->assertEquals($resultCode, $expectedCode);
+        $resultCodeArea = $floatCal->decode($expectedCode);
+        $this->assertTrue($resultCodeArea->contains($latitude, $longitude));
         if (PHP_INT_SIZE >= 8) {
             // at least 64-bit, which means we can use "long" ints here
             $intCal = new CodeCalculatorInt();
             $resultCode = $intCal->encode($latitude, $longitude, OpenLocationCode::CODE_PRECISION_NORMAL);
             $this->assertEquals($resultCode, $expectedCode);
+            $resultCodeArea = $intCal->decode($expectedCode);
+            $this->assertTrue($resultCodeArea->contains($latitude, $longitude));
         }
     }
 


### PR DESCRIPTION
If a 64-bit PHP version is detected (i.e., the int is "long"), then provide an alternative code calculator that uses the "long" ints. This ensures the intended correctness and good performance on 64-bit devices that are using PHP.

---

Other changes:

This also fixes a PHPDoc error in OpenLocationCode.